### PR TITLE
chore: lock missing package versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,3 @@ target/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
-
-rust-toolchain.toml

--- a/README.md
+++ b/README.md
@@ -64,6 +64,20 @@ This is very slow and on first boot OSSM-RS will change it to 115200 which requi
 
 If you check the logs you should see: `Motor baudrate updated. Please power cycle the machine!`
 
+### Developing OSSM-RS
+
+Open the entire workspace to build the firmware and make changes to xtask. Open the subdirectory ossm-rs to develop the firmware. Edit the [cargo config](ossm-rs/.cargo/config.toml#l15) with the appropriate build targets to better feedback from rust-analyzer.
+
+If using VSCode add a .vscode/settings.json with the following json to enable specific features (and thus boards) of ossm-rs
+
+```json
+{
+  "rust-analyzer.cargo.features": "board_ossm_alt_v2"
+}
+```
+
+This split is because there are multiple build targets and feature flags needed to build both xtask and ossm-rs - something that rust-analyzer does not support.
+
 ## Board Support
 
 ### See [supported boards](docs/supported_boards.md)

--- a/ossm-rs/Cargo.lock
+++ b/ossm-rs/Cargo.lock
@@ -85,7 +85,7 @@ dependencies = [
  "embedded-io",
  "embedded-io-async",
  "futures-intrusive",
- "heapless 0.9.1",
+ "heapless 0.8.0",
 ]
 
 [[package]]
@@ -562,18 +562,18 @@ dependencies = [
 
 [[package]]
 name = "enum-iterator"
-version = "2.1.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c280b9e6b3ae19e152d8e31cf47f18389781e119d4013a2a2bb0180e5facc635"
+checksum = "a4549325971814bda7a44061bf3fe7e487d447cba01e4220a4b454d630d7a016"
 dependencies = [
  "enum-iterator-derive",
 ]
 
 [[package]]
 name = "enum-iterator-derive"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ab991c1362ac86c61ab6f556cff143daa22e5a15e4e189df818b2fd19fe65b"
+checksum = "685adfa4d6f3d765a26bc5dbc936577de9abf756c1feeb3089b01dd395034842"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -623,7 +623,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 [[package]]
 name = "esp-alloc"
 version = "0.8.0"
-source = "git+https://github.com/orange-gem/esp-hal.git#e5fed5a2c918ff33e779d25d713e6beb879eccde"
+source = "git+https://github.com/orange-gem/esp-hal.git?rev=e5fed5a#e5fed5a2c918ff33e779d25d713e6beb879eccde"
 dependencies = [
  "allocator-api2",
  "cfg-if",
@@ -639,7 +639,7 @@ dependencies = [
 [[package]]
 name = "esp-backtrace"
 version = "0.17.0"
-source = "git+https://github.com/orange-gem/esp-hal.git#e5fed5a2c918ff33e779d25d713e6beb879eccde"
+source = "git+https://github.com/orange-gem/esp-hal.git?rev=e5fed5a#e5fed5a2c918ff33e779d25d713e6beb879eccde"
 dependencies = [
  "cfg-if",
  "document-features",
@@ -655,7 +655,7 @@ dependencies = [
 [[package]]
 name = "esp-bootloader-esp-idf"
 version = "0.2.0"
-source = "git+https://github.com/orange-gem/esp-hal.git#e5fed5a2c918ff33e779d25d713e6beb879eccde"
+source = "git+https://github.com/orange-gem/esp-hal.git?rev=e5fed5a#e5fed5a2c918ff33e779d25d713e6beb879eccde"
 dependencies = [
  "cfg-if",
  "document-features",
@@ -669,7 +669,7 @@ dependencies = [
 [[package]]
 name = "esp-config"
 version = "0.5.0"
-source = "git+https://github.com/orange-gem/esp-hal.git#e5fed5a2c918ff33e779d25d713e6beb879eccde"
+source = "git+https://github.com/orange-gem/esp-hal.git?rev=e5fed5a#e5fed5a2c918ff33e779d25d713e6beb879eccde"
 dependencies = [
  "document-features",
  "esp-metadata-generated",
@@ -681,7 +681,7 @@ dependencies = [
 [[package]]
 name = "esp-hal"
 version = "1.0.0-rc.0"
-source = "git+https://github.com/orange-gem/esp-hal.git#e5fed5a2c918ff33e779d25d713e6beb879eccde"
+source = "git+https://github.com/orange-gem/esp-hal.git?rev=e5fed5a#e5fed5a2c918ff33e779d25d713e6beb879eccde"
 dependencies = [
  "bitfield",
  "bitflags 2.9.3",
@@ -735,7 +735,7 @@ dependencies = [
 [[package]]
 name = "esp-hal-procmacros"
 version = "0.19.0"
-source = "git+https://github.com/orange-gem/esp-hal.git#e5fed5a2c918ff33e779d25d713e6beb879eccde"
+source = "git+https://github.com/orange-gem/esp-hal.git?rev=e5fed5a#e5fed5a2c918ff33e779d25d713e6beb879eccde"
 dependencies = [
  "document-features",
  "litrs",
@@ -750,7 +750,7 @@ dependencies = [
 [[package]]
 name = "esp-metadata"
 version = "0.8.0"
-source = "git+https://github.com/orange-gem/esp-hal.git#e5fed5a2c918ff33e779d25d713e6beb879eccde"
+source = "git+https://github.com/orange-gem/esp-hal.git?rev=e5fed5a#e5fed5a2c918ff33e779d25d713e6beb879eccde"
 dependencies = [
  "anyhow",
  "basic-toml",
@@ -764,7 +764,7 @@ dependencies = [
 [[package]]
 name = "esp-metadata-generated"
 version = "0.1.0"
-source = "git+https://github.com/orange-gem/esp-hal.git#e5fed5a2c918ff33e779d25d713e6beb879eccde"
+source = "git+https://github.com/orange-gem/esp-hal.git?rev=e5fed5a#e5fed5a2c918ff33e779d25d713e6beb879eccde"
 dependencies = [
  "esp-metadata",
 ]
@@ -772,7 +772,7 @@ dependencies = [
 [[package]]
 name = "esp-phy"
 version = "0.0.1"
-source = "git+https://github.com/orange-gem/esp-hal.git#e5fed5a2c918ff33e779d25d713e6beb879eccde"
+source = "git+https://github.com/orange-gem/esp-hal.git?rev=e5fed5a#e5fed5a2c918ff33e779d25d713e6beb879eccde"
 dependencies = [
  "cfg-if",
  "esp-config",
@@ -785,7 +785,7 @@ dependencies = [
 [[package]]
 name = "esp-println"
 version = "0.15.0"
-source = "git+https://github.com/orange-gem/esp-hal.git#e5fed5a2c918ff33e779d25d713e6beb879eccde"
+source = "git+https://github.com/orange-gem/esp-hal.git?rev=e5fed5a#e5fed5a2c918ff33e779d25d713e6beb879eccde"
 dependencies = [
  "defmt 1.0.1",
  "document-features",
@@ -798,7 +798,7 @@ dependencies = [
 [[package]]
 name = "esp-radio"
 version = "0.15.0"
-source = "git+https://github.com/orange-gem/esp-hal.git#e5fed5a2c918ff33e779d25d713e6beb879eccde"
+source = "git+https://github.com/orange-gem/esp-hal.git?rev=e5fed5a#e5fed5a2c918ff33e779d25d713e6beb879eccde"
 dependencies = [
  "allocator-api2",
  "bt-hci",
@@ -818,7 +818,7 @@ dependencies = [
  "esp-radio-rtos-driver",
  "esp-sync",
  "esp-wifi-sys",
- "heapless 0.9.1",
+ "heapless 0.9.2",
  "instability",
  "num-derive",
  "num-traits",
@@ -831,12 +831,12 @@ dependencies = [
 [[package]]
 name = "esp-radio-rtos-driver"
 version = "0.0.1"
-source = "git+https://github.com/orange-gem/esp-hal.git#e5fed5a2c918ff33e779d25d713e6beb879eccde"
+source = "git+https://github.com/orange-gem/esp-hal.git?rev=e5fed5a#e5fed5a2c918ff33e779d25d713e6beb879eccde"
 
 [[package]]
 name = "esp-riscv-rt"
 version = "0.12.0"
-source = "git+https://github.com/orange-gem/esp-hal.git#e5fed5a2c918ff33e779d25d713e6beb879eccde"
+source = "git+https://github.com/orange-gem/esp-hal.git?rev=e5fed5a#e5fed5a2c918ff33e779d25d713e6beb879eccde"
 dependencies = [
  "defmt 1.0.1",
  "document-features",
@@ -847,7 +847,7 @@ dependencies = [
 [[package]]
 name = "esp-rom-sys"
 version = "0.1.1"
-source = "git+https://github.com/orange-gem/esp-hal.git#e5fed5a2c918ff33e779d25d713e6beb879eccde"
+source = "git+https://github.com/orange-gem/esp-hal.git?rev=e5fed5a#e5fed5a2c918ff33e779d25d713e6beb879eccde"
 dependencies = [
  "cfg-if",
  "document-features",
@@ -857,7 +857,7 @@ dependencies = [
 [[package]]
 name = "esp-rtos"
 version = "0.0.1"
-source = "git+https://github.com/orange-gem/esp-hal.git#e5fed5a2c918ff33e779d25d713e6beb879eccde"
+source = "git+https://github.com/orange-gem/esp-hal.git?rev=e5fed5a#e5fed5a2c918ff33e779d25d713e6beb879eccde"
 dependencies = [
  "allocator-api2",
  "cfg-if",
@@ -879,7 +879,7 @@ dependencies = [
 [[package]]
 name = "esp-sync"
 version = "0.0.0"
-source = "git+https://github.com/orange-gem/esp-hal.git#e5fed5a2c918ff33e779d25d713e6beb879eccde"
+source = "git+https://github.com/orange-gem/esp-hal.git?rev=e5fed5a#e5fed5a2c918ff33e779d25d713e6beb879eccde"
 dependencies = [
  "cfg-if",
  "defmt 1.0.1",
@@ -1115,9 +1115,9 @@ dependencies = [
 
 [[package]]
 name = "heapless"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1edcd5a338e64688fbdcb7531a846cfd3476a54784dcb918a0844682bc7ada5"
+checksum = "2af2455f757db2b292a9b1768c4b70186d443bcb3b316252d6b540aec1cd89ed"
 dependencies = [
  "defmt 1.0.1",
  "hash32",
@@ -1355,7 +1355,7 @@ dependencies = [
  "esp-println",
  "esp-radio",
  "esp-rtos",
- "heapless 0.9.1",
+ "heapless 0.9.2",
  "num-traits",
  "portable-atomic",
  "rmodbus",
@@ -1571,7 +1571,7 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae086fe401655097112f1bd988012c0334d19b0c495128b256f1506873c6ba8f"
 dependencies = [
- "heapless 0.9.1",
+ "heapless 0.9.2",
  "ieee754",
 ]
 
@@ -1829,9 +1829,9 @@ dependencies = [
 
 [[package]]
 name = "trouble-host"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78a852f6e193f71732ce3c33661fea2575ba3dac6f48bbe1713059373f96e864"
+checksum = "2881b4859001fe1f48445145cda5149deac9110b1d707ec0a251b7ff6d8bdfa4"
 dependencies = [
  "bt-hci",
  "defmt 1.0.1",
@@ -1840,7 +1840,7 @@ dependencies = [
  "embassy-time",
  "embedded-io",
  "futures",
- "heapless 0.9.1",
+ "heapless 0.9.2",
  "rand_core 0.6.4",
  "static_cell",
  "trouble-host-macros",
@@ -2132,7 +2132,7 @@ dependencies = [
 [[package]]
 name = "xtensa-lx"
 version = "0.12.0"
-source = "git+https://github.com/orange-gem/esp-hal.git#e5fed5a2c918ff33e779d25d713e6beb879eccde"
+source = "git+https://github.com/orange-gem/esp-hal.git?rev=e5fed5a#e5fed5a2c918ff33e779d25d713e6beb879eccde"
 dependencies = [
  "critical-section",
 ]
@@ -2140,7 +2140,7 @@ dependencies = [
 [[package]]
 name = "xtensa-lx-rt"
 version = "0.20.0"
-source = "git+https://github.com/orange-gem/esp-hal.git#e5fed5a2c918ff33e779d25d713e6beb879eccde"
+source = "git+https://github.com/orange-gem/esp-hal.git?rev=e5fed5a#e5fed5a2c918ff33e779d25d713e6beb879eccde"
 dependencies = [
  "defmt 1.0.1",
  "document-features",
@@ -2151,7 +2151,7 @@ dependencies = [
 [[package]]
 name = "xtensa-lx-rt-proc-macros"
 version = "0.4.0"
-source = "git+https://github.com/orange-gem/esp-hal.git#e5fed5a2c918ff33e779d25d713e6beb879eccde"
+source = "git+https://github.com/orange-gem/esp-hal.git?rev=e5fed5a#e5fed5a2c918ff33e779d25d713e6beb879eccde"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2160,18 +2160,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.27"
+version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+checksum = "668f5168d10b9ee831de31933dc111a459c97ec93225beb307aed970d1372dfd"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.27"
+version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+checksum = "2c7962b26b0a8685668b671ee4b54d007a67d4eaf05fda79ac0ecf41e32270f1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/ossm-rs/Cargo.toml
+++ b/ossm-rs/Cargo.toml
@@ -6,35 +6,35 @@ version = "0.1.0"
 
 [dependencies]
 defmt = "1.0.1"
-esp-bootloader-esp-idf = { version = "0.2.0", git = "https://github.com/orange-gem/esp-hal.git" }
-esp-hal = { version = "=1.0.0-rc.0", features = [
+esp-bootloader-esp-idf = { git = "https://github.com/orange-gem/esp-hal.git", rev = "e5fed5a" }
+esp-hal = { features = [
     "defmt",
     "unstable",
-], git = "https://github.com/orange-gem/esp-hal.git" }
+], git = "https://github.com/orange-gem/esp-hal.git", rev = "e5fed5a" }
 
 esp-rtos = { features = [
     "embassy",
     "defmt",
-], git = "https://github.com/orange-gem/esp-hal.git" }
+], git = "https://github.com/orange-gem/esp-hal.git", rev = "e5fed5a" }
 esp-radio = { features = [
     "ble",
     "defmt",
     "esp-now",
     "unstable",
     "wifi",
-], git = "https://github.com/orange-gem/esp-hal.git" }
+], git = "https://github.com/orange-gem/esp-hal.git", rev = "e5fed5a" }
 embedded-io = { version = "0.6.1", features = ["defmt-03"] }
 embedded-io-async = { version = "0.6.1", features = ["defmt-03"] }
 esp-alloc = { features = [
     "defmt",
-], git = "https://github.com/orange-gem/esp-hal.git" }
+], git = "https://github.com/orange-gem/esp-hal.git", rev = "e5fed5a" }
 esp-backtrace = { features = [
     "println",
     "panic-handler",
-], git = "https://github.com/orange-gem/esp-hal.git" }
+], git = "https://github.com/orange-gem/esp-hal.git", rev = "e5fed5a" }
 esp-println = { features = [
     "defmt-espflash",
-], git = "https://github.com/orange-gem/esp-hal.git" }
+], git = "https://github.com/orange-gem/esp-hal.git", rev = "e5fed5a" }
 critical-section = "1.2.0"
 embassy-executor = { version = "0.9.1", features = ["defmt"] }
 embassy-time = { version = "0.5.0", features = ["defmt"] }
@@ -100,7 +100,6 @@ board_ossm_v3 = ["board_selected", "esp32s3"]
 board_ossm_alt_v2 = ["board_selected", "esp32c6"]
 board_custom_s3 = ["board_selected", "esp32s3"]
 board_custom_c6 = ["board_selected", "esp32c6"]
-
 
 [profile.release]
 codegen-units = 1        # LLVM can perform better optimizations using a single thread

--- a/xtask/rust-toolchain.toml
+++ b/xtask/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "stable"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,8 +1,6 @@
 use serde::Serialize;
 use std::{
     env,
-    fs::File,
-    io::Write,
     path::{Path, PathBuf},
     process::Command,
 };
@@ -24,11 +22,6 @@ struct Toolchain {
     channel: String,
     components: Option<Vec<String>>,
     targets: Option<Vec<String>>,
-}
-
-#[derive(Serialize)]
-struct ToolchainFile {
-    toolchain: Toolchain,
 }
 
 impl Mcu {


### PR DESCRIPTION
This PR is meant to fix version references in the cargo toml for ossm-rs:

1. version numbers are not used when git is also used, so I've removed them here to prevent confusion.
2. without a revision, the HEAD of the git repo is used. This is troublesome as when any dependency is updated/changed, the git repos are refetched and the lockfile updated with the new revision. This caused a headache when working on these updates as the repo has since been rebased and HEAD contains new breaking changes.

I've also added some documentation on how to develop more effectively so people don't try and make the same structural changes I did.